### PR TITLE
Setting to auto-format decoded JWTs

### DIFF
--- a/JWTDecode.sublime-settings
+++ b/JWTDecode.sublime-settings
@@ -1,0 +1,5 @@
+// JWTDecode Default Settings
+{
+    // Whether or not to format the decoded result using JSON Pretty. 
+    "format_on_decode": false,
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,23 @@
+[
+  { "id": "preferences",
+    "children": [
+      { "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children": [
+          { "caption": "JWT Decode",
+            "children": [
+              { "caption": "Settings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/JWT Decode/JWTDecode.sublime-settings",
+                  "default": "{\n\t$0\n}\n"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/jwt.py
+++ b/jwt.py
@@ -86,7 +86,6 @@ def get_json_formatter_command():
         return None
 
     if formatter in ignored_packages:
-        FORMATTER_FOUND = None
         sublime.status_message('Unable to format decoded output: package "Pretty JSON" is installed, but in your "ignored_packages"')
         return None
     


### PR DESCRIPTION
Added `.sublime-settings` along with `.sublime-menu` to open and edit the configuration.

Default setting is false.

For now only supporting 'Pretty JSON' and checking if it's installed and enabled.

Could potentially be extended to allow other formatters by checking a list of known plugins in `get_json_formatter_command` and returning the corresponding command name.